### PR TITLE
Fixed issue with ON DELETE CASCADE

### DIFF
--- a/backend/src/sql/1.addPromoCodes.sql
+++ b/backend/src/sql/1.addPromoCodes.sql
@@ -25,8 +25,7 @@ create table promo_code_uses
     server_id uuid                                               not null,
     used      timestamp with time zone default CURRENT_TIMESTAMP not null,
     constraint promo_code_uses_pk
-        primary key (game_id, code, player_id)
-            on delete cascade,
+        primary key (game_id, code, player_id),
     constraint promo_codes_use_promo_codes_game_id_code_fk
         foreign key (game_id, code) references promo_codes
             on delete cascade


### PR DESCRIPTION
There is a ON DELETE CASCADE within the PRIMARY KEY constraint, which is not allowed. Has no point and will throw an error. So its removed.